### PR TITLE
Add namespaces to avoid clashes with classes in consumer projects

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -1,6 +1,9 @@
 using System;
 
-public static class Config {
-  public static string API = "https://api.bullet-train.io/api/v1/";
-
+namespace SolidStateGroup.BulletTrain
+{
+  public static class Config
+  {
+    public static string API = "https://api.bullet-train.io/api/v1/";
+  }
 }

--- a/Trait.cs
+++ b/Trait.cs
@@ -1,26 +1,30 @@
 using System;
 using Newtonsoft.Json;
 
-[JsonObject(MemberSerialization.OptIn)]
-public class Trait
+namespace SolidStateGroup.BulletTrain
 {
-  [JsonProperty("trait_key")]
-  private string key;
-
-  [JsonProperty("trait_value")]
-  private string value;
-
-  public string GetKey()
+  [JsonObject(MemberSerialization.OptIn)]
+  public class Trait
   {
-    return key;
-  }
+    [JsonProperty("trait_key")]
+    private string key;
 
-  public string GetValue()
-  {
-    return value;
-  }
+    [JsonProperty("trait_value")]
+    private string value;
 
-  public override string ToString() {
-    return JsonConvert.SerializeObject(this);
+    public string GetKey()
+    {
+      return key;
+    }
+
+    public string GetValue()
+    {
+      return value;
+    }
+
+    public override string ToString()
+    {
+      return JsonConvert.SerializeObject(this);
+    }
   }
 }


### PR DESCRIPTION
The specific use case for this PR is that when trying to use this client in my own project, the `Config` class clashes with another `Config` class specified in my project. Therefore, I've added in the same namespace as what's defined in the other classes so that it won't clash going forward.