### PR TITLE
Allow API url to be defined when creating an instance of the BulletTrainClient

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -23,6 +23,11 @@ namespace SolidStateGroup.BulletTrain
                     "Parameter must be provided when constructing an instance of the client.");
             }
 
+            if (!bulletTrainConfiguration.IsValid())
+            {
+                throw new ArgumentException("The provided configuration is not valid. An API Url and Environment Key must be provided.", nameof(bulletTrainConfiguration));
+            }
+
             if (!isInitialized)
             {
                 configuration = bulletTrainConfiguration;

--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -14,9 +14,10 @@ namespace SolidStateGroup.BulletTrain
 
         private static readonly HttpClient httpClient;
 
-        static BulletTrainClient() {
+        static BulletTrainClient()
+        {
             var sp = ServicePointManager.FindServicePoint(new Uri(Config.API));
-            sp.ConnectionLeaseTimeout = 60*1000*5;
+            sp.ConnectionLeaseTimeout = 60 * 1000 * 5;
             httpClient = new HttpClient();
         }
 
@@ -28,26 +29,30 @@ namespace SolidStateGroup.BulletTrain
             string url;
             if (identity == null)
             {
-                url = Config.API +  "flags/";
+                url = Config.API + "flags/";
             }
             else
             {
                 url = Config.API + "identities/" + identity + "/";
             }
 
-            try {
+            try
+            {
                 string json = await GetJSON(HttpMethod.Get, url);
 
-                if (identity == null) {
+                if (identity == null)
+                {
                     return JsonConvert.DeserializeObject<List<Flag>>(json);
-                } else {
+                }
+                else
+                {
                     return JsonConvert.DeserializeObject<Identity>(json).flags;
                 }
             }
             catch (JsonException e)
             {
                 Console.WriteLine("\nJSON Exception Caught!");
-                Console.WriteLine("Message :{0} ",e.Message);
+                Console.WriteLine("Message :{0} ", e.Message);
                 return null;
             }
         }
@@ -58,8 +63,10 @@ namespace SolidStateGroup.BulletTrain
         public async Task<bool> HasFeatureFlag(string featureId, string identity = null)
         {
             List<Flag> flags = await GetFeatureFlags(identity);
-            foreach (Flag flag in flags) {
-                if (flag.GetFeature().GetName().Equals(featureId) && flag.IsEnabled()) {
+            foreach (Flag flag in flags)
+            {
+                if (flag.GetFeature().GetName().Equals(featureId) && flag.IsEnabled())
+                {
                     return true;
                 }
             }
@@ -73,8 +80,10 @@ namespace SolidStateGroup.BulletTrain
         public async Task<string> GetFeatureValue(string featureId, string identity = null)
         {
             List<Flag> flags = await GetFeatureFlags(identity);
-            foreach (Flag flag in flags) {
-                if (flag.GetFeature().GetName().Equals(featureId)) {
+            foreach (Flag flag in flags)
+            {
+                if (flag.GetFeature().GetName().Equals(featureId))
+                {
                     return flag.GetValue();
                 }
             }
@@ -85,18 +94,23 @@ namespace SolidStateGroup.BulletTrain
         /// <summary>
         /// Get all user traits for provided identity. Optionally filter results with a list of keys
         /// </summary>
-        public async Task<List<Trait>> GetTraits(string identity, List<string> keys = null) {
-            try {
+        public async Task<List<Trait>> GetTraits(string identity, List<string> keys = null)
+        {
+            try
+            {
                 string json = await GetJSON(HttpMethod.Get, Config.API + "identities/" + identity + "/");
 
                 List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json).traits;
-                if (keys == null) {
+                if (keys == null)
+                {
                     return traits;
                 }
 
                 List<Trait> filteredTraits = new List<Trait>();
-                foreach (Trait trait in traits) {
-                    if (keys.Contains(trait.GetKey())) {
+                foreach (Trait trait in traits)
+                {
+                    if (keys.Contains(trait.GetKey()))
+                    {
                         filteredTraits.Add(trait);
                     }
                 }
@@ -106,7 +120,7 @@ namespace SolidStateGroup.BulletTrain
             catch (JsonException e)
             {
                 Console.WriteLine("\nJSON Exception Caught!");
-                Console.WriteLine("Message :{0} ",e.Message);
+                Console.WriteLine("Message :{0} ", e.Message);
                 return null;
             }
         }
@@ -118,8 +132,10 @@ namespace SolidStateGroup.BulletTrain
         {
             List<Trait> traits = await GetTraits(identity);
 
-            foreach (Trait trait in traits) {
-                if (trait.GetKey().Equals(key)) {
+            foreach (Trait trait in traits)
+            {
+                if (trait.GetKey().Equals(key))
+                {
                     return trait.GetValue();
                 }
             }
@@ -132,7 +148,8 @@ namespace SolidStateGroup.BulletTrain
         /// </summary>
         public async Task<Trait> SetTrait(string identity, string key, string value)
         {
-            try {
+            try
+            {
                 string json = await GetJSON(HttpMethod.Post, Config.API + "identities/" + identity + "/traits/" + key, JsonConvert.SerializeObject(new { trait_value = value }));
 
                 return JsonConvert.DeserializeObject<Trait>(json);
@@ -140,7 +157,7 @@ namespace SolidStateGroup.BulletTrain
             catch (JsonException e)
             {
                 Console.WriteLine("\nJSON Exception Caught!");
-                Console.WriteLine("Message :{0} ",e.Message);
+                Console.WriteLine("Message :{0} ", e.Message);
                 return null;
             }
         }
@@ -150,7 +167,8 @@ namespace SolidStateGroup.BulletTrain
         /// </summary>
         public async Task<Identity> GetUserIdentity(string identity)
         {
-            try {
+            try
+            {
                 string json = await GetJSON(HttpMethod.Get, Config.API + "identities/" + identity + "/");
 
                 return JsonConvert.DeserializeObject<Identity>(json);
@@ -158,19 +176,23 @@ namespace SolidStateGroup.BulletTrain
             catch (JsonException e)
             {
                 Console.WriteLine("\nJSON Exception Caught!");
-                Console.WriteLine("Message :{0} ",e.Message);
+                Console.WriteLine("Message :{0} ", e.Message);
                 return null;
             }
         }
 
-        private async Task<string> GetJSON(HttpMethod method, string url, string body = null) {
-            try {
-                HttpRequestMessage request = new HttpRequestMessage(method, url) {
+        private async Task<string> GetJSON(HttpMethod method, string url, string body = null)
+        {
+            try
+            {
+                HttpRequestMessage request = new HttpRequestMessage(method, url)
+                {
                     Headers = {
                         { "X-Environment-Key", environmentKey }
                     }
                 };
-                if (body != null) {
+                if (body != null)
+                {
                     request.Content = new StringContent(body, Encoding.UTF8, "application/json");
                 }
                 HttpResponseMessage response = await httpClient.SendAsync(request);
@@ -180,7 +202,7 @@ namespace SolidStateGroup.BulletTrain
             catch (HttpRequestException e)
             {
                 Console.WriteLine("\nHTTP Request Exception Caught!");
-                Console.WriteLine("Message :{0} ",e.Message);
+                Console.WriteLine("Message :{0} ", e.Message);
                 return null;
             }
         }

--- a/BulletTrainConfiguration.cs
+++ b/BulletTrainConfiguration.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace SolidStateGroup.BulletTrain
+{
+    public class BulletTrainConfiguration
+    {
+        public string ApiUrl = "https://api.bullet-train.io/api/v1/";
+        public string EnvironmentKey = "";
+    }
+}

--- a/BulletTrainConfiguration.cs
+++ b/BulletTrainConfiguration.cs
@@ -6,5 +6,10 @@ namespace SolidStateGroup.BulletTrain
     {
         public string ApiUrl = "https://api.bullet-train.io/api/v1/";
         public string EnvironmentKey = "";
+
+        public bool IsValid()
+        {
+            return !string.IsNullOrWhiteSpace(ApiUrl) && !string.IsNullOrEmpty(EnvironmentKey);
+        }
     }
 }

--- a/Config.cs
+++ b/Config.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace SolidStateGroup.BulletTrain
-{
-    public static class Config
-    {
-        public static string API = "https://api.bullet-train.io/api/v1/";
-    }
-}

--- a/Config.cs
+++ b/Config.cs
@@ -1,6 +1,9 @@
 using System;
 
-public static class Config {
-  public static string API = "https://api.bullet-train.io/api/v1/";
-
+namespace SolidStateGroup.BulletTrain
+{
+  public static class Config
+  {
+    public static string API = "https://api.bullet-train.io/api/v1/";
+  }
 }

--- a/Config.cs
+++ b/Config.cs
@@ -2,8 +2,8 @@ using System;
 
 namespace SolidStateGroup.BulletTrain
 {
-  public static class Config
-  {
-    public static string API = "https://api.bullet-train.io/api/v1/";
-  }
+    public static class Config
+    {
+        public static string API = "https://api.bullet-train.io/api/v1/";
+    }
 }

--- a/Feature.cs
+++ b/Feature.cs
@@ -3,18 +3,20 @@ using Newtonsoft.Json;
 
 namespace SolidStateGroup.BulletTrain
 {
-  [JsonObject(MemberSerialization.OptIn)]
-  public class Feature
-  {
-    [JsonProperty]
-    private string name;
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Feature
+    {
+        [JsonProperty]
+        private string name;
 
-    public string GetName() {
-      return name;
-    }
+        public string GetName()
+        {
+            return name;
+        }
 
-    public override string ToString() {
-      return JsonConvert.SerializeObject(this);
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
     }
-  }
 }

--- a/Flag.cs
+++ b/Flag.cs
@@ -3,32 +3,36 @@ using Newtonsoft.Json;
 
 namespace SolidStateGroup.BulletTrain
 {
-  [JsonObject(MemberSerialization.OptIn)]
-  public class Flag
-  {
-    [JsonProperty]
-    private Feature feature;
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Flag
+    {
+        [JsonProperty]
+        private Feature feature;
 
-    [JsonProperty]
-    private bool enabled;
+        [JsonProperty]
+        private bool enabled;
 
-    [JsonProperty("feature_state_value")]
-    private string value;
+        [JsonProperty("feature_state_value")]
+        private string value;
 
-    public override string ToString() {
-      return JsonConvert.SerializeObject(this);
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+
+        public Feature GetFeature()
+        {
+            return feature;
+        }
+
+        public bool IsEnabled()
+        {
+            return enabled;
+        }
+
+        public string GetValue()
+        {
+            return value;
+        }
     }
-
-    public Feature GetFeature() {
-      return feature;
-    }
-
-    public bool IsEnabled() {
-      return enabled;
-    }
-
-    public string GetValue() {
-      return value;
-    }
-  }
 }

--- a/Identity.cs
+++ b/Identity.cs
@@ -4,17 +4,18 @@ using Newtonsoft.Json;
 
 namespace SolidStateGroup.BulletTrain
 {
-  [JsonObject(MemberSerialization.OptIn)]
-  public class Identity
-  {
-    [JsonProperty]
-    public List<Flag> flags;
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Identity
+    {
+        [JsonProperty]
+        public List<Flag> flags;
 
-    [JsonProperty]
-    public List<Trait> traits;
+        [JsonProperty]
+        public List<Trait> traits;
 
-    public override string ToString() {
-      return JsonConvert.SerializeObject(this);
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
     }
-  }
 }

--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ The client library is available from NuGet and can be added to your project by m
 
 Sign Up and create account at [https://bullet-train.io/](https://www.bullet-train.io/)
 
-In your application initialise the Bullet Train client with your environment API key
+In your application initialise the Bullet Train client with your environment API key and API URL.
 
 ```c#
-BulletTrainClient bulletClient = new BulletTrainClient() {
-  environmentKey: "<environment-key-here>"
+BulletTrainConfiguration configuration = new BulletTrainConfiguration()
+{
+    ApiUrl = "https://api.bullet-train.io/api/v1/",
+    EnvironmentKey = "env-key-goes-here"
 };
+
+BulletTrainClient bulletClient = new BulletTrainClient(configuration);
 ```
 
 To check if a feature flag exists and is enabled:

--- a/Trait.cs
+++ b/Trait.cs
@@ -3,28 +3,28 @@ using Newtonsoft.Json;
 
 namespace SolidStateGroup.BulletTrain
 {
-  [JsonObject(MemberSerialization.OptIn)]
-  public class Trait
-  {
-    [JsonProperty("trait_key")]
-    private string key;
-
-    [JsonProperty("trait_value")]
-    private string value;
-
-    public string GetKey()
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Trait
     {
-      return key;
-    }
+        [JsonProperty("trait_key")]
+        private string key;
 
-    public string GetValue()
-    {
-      return value;
-    }
+        [JsonProperty("trait_value")]
+        private string value;
 
-    public override string ToString()
-    {
-      return JsonConvert.SerializeObject(this);
+        public string GetKey()
+        {
+            return key;
+        }
+
+        public string GetValue()
+        {
+            return value;
+        }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
     }
-  }
 }

--- a/Trait.cs
+++ b/Trait.cs
@@ -1,26 +1,30 @@
 using System;
 using Newtonsoft.Json;
 
-[JsonObject(MemberSerialization.OptIn)]
-public class Trait
+namespace SolidStateGroup.BulletTrain
 {
-  [JsonProperty("trait_key")]
-  private string key;
-
-  [JsonProperty("trait_value")]
-  private string value;
-
-  public string GetKey()
+  [JsonObject(MemberSerialization.OptIn)]
+  public class Trait
   {
-    return key;
-  }
+    [JsonProperty("trait_key")]
+    private string key;
 
-  public string GetValue()
-  {
-    return value;
-  }
+    [JsonProperty("trait_value")]
+    private string value;
 
-  public override string ToString() {
-    return JsonConvert.SerializeObject(this);
+    public string GetKey()
+    {
+      return key;
+    }
+
+    public string GetValue()
+    {
+      return value;
+    }
+
+    public override string ToString()
+    {
+      return JsonConvert.SerializeObject(this);
+    }
   }
 }

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using SolidStateGroup.BulletTrain;
+using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using SolidStateGroup.BulletTrain;
 
 namespace example
 {
@@ -9,9 +8,13 @@ namespace example
     {
         static void Main(string[] args)
         {
-            BulletTrainClient client = new BulletTrainClient() {
-                environmentKey = "env-key-goes-here"
+            BulletTrainConfiguration configuration = new BulletTrainConfiguration()
+            {
+                ApiUrl = "https://api.bullet-train.io/api/v1/",
+                EnvironmentKey = "env-key-goes-here"
             };
+
+            BulletTrainClient client = new BulletTrainClient(configuration);
 
             // Get all flags
             List<Flag> flags = client.GetFeatureFlags().GetAwaiter().GetResult();


### PR DESCRIPTION
This pull request is dependent on https://github.com/BulletTrainHQ/bullet-train-dotnet-client/pull/3 as the namespace changes are included when making the style consistent across all files (there was a variation in style where 1 file used tabs, the other spaces).

When constructing the client, it is not possible (from what I saw) to specify the BulletTrain API url. This is a necessity for me as I am currently trying to host BulletTrain locally. I'd thought that others might be having the same problem which could discourage people from trying this client library. I'd recommend that if this pull request is accepted, it be released as a v2 as it breaks existing consumers when constructing an instance of the client.

I was not sure of the exact purpose of the `ServicePointManager` in the context of this library, but I left the code as is and tried to maintain the functionality with regards to how you are creating a static instance of the `HttpClient`.