### PR TITLE
fix: problems with configuration of API

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Text;
-using System.Dynamic;
 using Newtonsoft.Json;
 
 namespace BulletTrain
@@ -36,7 +35,9 @@ namespace BulletTrain
                 sp.ConnectionLeaseTimeout = 60 * 1000 * 5;
                 httpClient = new HttpClient();
                 instance = this;
-            } else {
+            }
+            else
+            {
                 throw new NotSupportedException("BulletTrainClient should only be initialised once. Use BulletTrainClient.instance after successful initialisation");
             }
         }
@@ -49,11 +50,11 @@ namespace BulletTrain
             string url;
             if (identity == null)
             {
-                url = $"{configuration.ApiUrl}flags/";
+                url = configuration.ApiUrl.AppendPath("flags");
             }
             else
             {
-                url = $"{configuration.ApiUrl}identities/{identity}/";
+                url = configuration.ApiUrl.AppendPath("identities", identity);
             }
 
             try
@@ -118,7 +119,8 @@ namespace BulletTrain
         {
             try
             {
-                string json = await GetJSON(HttpMethod.Get, $"{configuration.ApiUrl}identities/{identity}/");
+                string url = configuration.ApiUrl.AppendPath("identities", identity);
+                string json = await GetJSON(HttpMethod.Get, url);
 
                 List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json).traits;
                 if (keys == null)
@@ -206,11 +208,13 @@ namespace BulletTrain
         {
             try
             {
-                if (!(value is bool) && !(value is int) && !(value is string)) {
+                if (!(value is bool) && !(value is int) && !(value is string))
+                {
                     throw new ArgumentException("Value parameter must be string, int or boolean");
                 }
-                
-                string json = await GetJSON(HttpMethod.Post, $"{configuration.ApiUrl}traits/", JsonConvert.SerializeObject(new { identity = new { identifier = identity }, trait_key = key, trait_value = value }));
+
+                string url = configuration.ApiUrl.AppendPath("traits");
+                string json = await GetJSON(HttpMethod.Post, url, JsonConvert.SerializeObject(new { identity = new { identifier = identity }, trait_key = key, trait_value = value }));
 
                 return JsonConvert.DeserializeObject<Trait>(json);
             }
@@ -235,7 +239,8 @@ namespace BulletTrain
         {
             try
             {
-                string json = await GetJSON(HttpMethod.Post, $"{configuration.ApiUrl}traits/increment-value/", 
+                string url = configuration.ApiUrl.AppendPath("traits", "increment-value");
+                string json = await GetJSON(HttpMethod.Post, url,
                     JsonConvert.SerializeObject(new { identifier = identity, trait_key = key, increment_by = incrementBy }));
 
                 return JsonConvert.DeserializeObject<Trait>(json);
@@ -255,7 +260,8 @@ namespace BulletTrain
         {
             try
             {
-                string json = await GetJSON(HttpMethod.Get, $"{configuration.ApiUrl}identities/{identity}/");
+                string url = configuration.ApiUrl.AppendPath("identities", identity);
+                string json = await GetJSON(HttpMethod.Get, url);
 
                 return JsonConvert.DeserializeObject<Identity>(json);
             }

--- a/BulletTrainConfiguration.cs
+++ b/BulletTrainConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace BulletTrain
+﻿namespace BulletTrain
 {
     public class BulletTrainConfiguration
     {
@@ -15,7 +13,7 @@ namespace BulletTrain
 
         public bool IsValid()
         {
-            return !Uri.TryCreate(ApiUrl, UriKind.RelativeOrAbsolute, out _) && !string.IsNullOrEmpty(EnvironmentKey);
+            return !string.IsNullOrEmpty(ApiUrl) && !string.IsNullOrEmpty(EnvironmentKey);
         }
     }
 }

--- a/BulletTrainConfiguration.cs
+++ b/BulletTrainConfiguration.cs
@@ -1,13 +1,21 @@
+﻿using System;
+
 namespace BulletTrain
 {
     public class BulletTrainConfiguration
     {
-        public string ApiUrl = "https://api.bullet-train.io/api/v1/";
-        public string EnvironmentKey = "";
+        public BulletTrainConfiguration()
+        {
+            ApiUrl = "https://api.bullet-train.io/api/v1/";
+            EnvironmentKey = string.Empty;
+        }
+
+        public string ApiUrl { get; set; }
+        public string EnvironmentKey { get; set; }
 
         public bool IsValid()
         {
-            return !string.IsNullOrWhiteSpace(ApiUrl) && !string.IsNullOrEmpty(EnvironmentKey);
+            return !Uri.TryCreate(ApiUrl, UriKind.RelativeOrAbsolute, out _) && !string.IsNullOrEmpty(EnvironmentKey);
         }
     }
 }

--- a/UrlExtensions.cs
+++ b/UrlExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Text;
+
+namespace BulletTrain
+{
+    internal static class UrlExtensions
+    {
+        public static string AppendPath(this string url, params string[] urlSegments)
+        {
+            var builder = new StringBuilder(url);
+            if (!url.EndsWith("/"))
+            {
+                builder.Append('/');
+            }
+
+            foreach (var segment in urlSegments)
+            {
+                builder.Append(segment);
+                if (!segment.EndsWith("/"))
+                {
+                    builder.Append('/');
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
The issue is $"{configuration.ApiUrl}flags/" can end up in the wrong URL when `ApiUrl` doesn't end with `/`.

It's the same as with the path, it should be better to combine it properly.