### PR TITLE
fix: update of calling deprecated API '/identities/{identifier}/'

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -54,7 +54,7 @@ namespace BulletTrain
             }
             else
             {
-                url = configuration.ApiUrl.AppendPath("identities", identity);
+                url = configuration.ApiUrl.AppendPath("identities",$"?identifier={identity}");
             }
 
             try


### PR DESCRIPTION
update calling '/identities/{identifier}/' from deprecated version to actual API '/identities/?identifier=<identifier>' by API documentation https://api.bullet-train.io/api/v1/docs/