### PR TITLE
feat: bullet train client can use legacy identities and new ones

### DIFF
--- a/BulletTrainClient.cs
+++ b/BulletTrainClient.cs
@@ -54,7 +54,7 @@ namespace BulletTrain
             }
             else
             {
-                url = $"{configuration.ApiUrl}identities/{identity}/";
+                url = GetIdentitiesUrl(identity);
             }
 
             try
@@ -119,7 +119,7 @@ namespace BulletTrain
         {
             try
             {
-                string url = configuration.ApiUrl.AppendPath("identities", identity);
+                string url = GetIdentitiesUrl(identity);
                 string json = await GetJSON(HttpMethod.Get, url);
 
                 List<Trait> traits = JsonConvert.DeserializeObject<Identity>(json).traits;
@@ -260,7 +260,7 @@ namespace BulletTrain
         {
             try
             {
-                string url = configuration.ApiUrl.AppendPath("identities", identity);
+                string url = GetIdentitiesUrl(identity); 
                 string json = await GetJSON(HttpMethod.Get, url);
 
                 return JsonConvert.DeserializeObject<Identity>(json);
@@ -297,6 +297,16 @@ namespace BulletTrain
                 Console.WriteLine("Message :{0} ", e.Message);
                 return null;
             }
+        }
+
+        private string GetIdentitiesUrl(string identity)
+        {
+            if (configuration.UseLegacyIdentities)
+            {
+                return configuration.ApiUrl.AppendPath("identities", identity);
+            }
+
+            return configuration.ApiUrl.AppendToUrl(trailingSlash: false, "identities", $"?identifier={identity}");
         }
     }
 }

--- a/BulletTrainConfiguration.cs
+++ b/BulletTrainConfiguration.cs
@@ -6,11 +6,12 @@
         {
             ApiUrl = "https://api.bullet-train.io/api/v1/";
             EnvironmentKey = string.Empty;
+            UseLegacyIdentities = true;
         }
 
         public string ApiUrl { get; set; }
         public string EnvironmentKey { get; set; }
-        public bool UseLegacyIdentities { get; set; } = true;
+        public bool UseLegacyIdentities { get; set; }
 
         public bool IsValid()
         {

--- a/BulletTrainConfiguration.cs
+++ b/BulletTrainConfiguration.cs
@@ -10,6 +10,7 @@
 
         public string ApiUrl { get; set; }
         public string EnvironmentKey { get; set; }
+        public bool UseLegacyIdentities { get; set; } = true;
 
         public bool IsValid()
         {

--- a/UrlExtensions.cs
+++ b/UrlExtensions.cs
@@ -6,6 +6,11 @@ namespace BulletTrain
     {
         public static string AppendPath(this string url, params string[] urlSegments)
         {
+            return url.AppendToUrl(true, urlSegments);
+        }
+
+        public static string AppendToUrl(this string url, bool trailingSlash, params string[] urlSegments)
+        {
             var builder = new StringBuilder(url);
             if (!url.EndsWith("/"))
             {
@@ -21,7 +26,7 @@ namespace BulletTrain
                 }
             }
 
-            return builder.ToString();
+            return trailingSlash ? builder.ToString() : builder.ToString(0, builder.Length - 1);
         }
     }
 }


### PR DESCRIPTION
`GetIdentitiesUrl` will help to distinguish between legacy and actual endpoint.

- It's set to use legacy by default to not break current usages.

#12 